### PR TITLE
feat: Add CNNClassifier.

### DIFF
--- a/config/ted/asr_sam_cnnclassifier.yaml
+++ b/config/ted/asr_sam_cnnclassifier.yaml
@@ -22,8 +22,8 @@ data:
 
 hparas:                                   # Experiment hyper-parameters
 #  valid_step: 5000
-  valid_step: 100
-  max_step: 1000
+  valid_step: 2000
+  max_step: 1000001
   tf_start: 1.0
   tf_end: 1.0
   tf_step: 500000

--- a/config/ted/asr_sam_cnnclassifier.yaml
+++ b/config/ted/asr_sam_cnnclassifier.yaml
@@ -1,0 +1,62 @@
+data:
+  corpus:                                 
+    name: 'Tedsrt'                   # Specify corpus
+    path: 'data/TedSrt'          # Path to raw LibriSpeech dataset
+#    train_split: ['train-clean-100','train-clean-360'] # Name of data splits to be used as training set
+    train_split: ['train'] # Name of data splits to be used as training set
+    dev_split: ['dev']              # Name of data splits to be used as validation set
+    bucketing: False                       # Enable/Disable bucketing
+    batch_size: 2
+  audio:                                  # Attributes of audio feature
+    feat_type: 'mfcc'
+    feat_dim:  13
+    frame_length: 25                      # ms
+    frame_shift: 10                       # ms
+    dither: 0                             # random dither audio, 0: no dither
+    apply_cmvn: True
+    delta_order: 2                        # 0: do nothing, 1: add delta, 2: add delta and accelerate
+    delta_window_size: 2
+  text:
+    mode: 'subword'                       # 'character'/'word'/'subword'
+    vocab_file: 'tests/sample_data/subword-16k.model'
+
+hparas:                                   # Experiment hyper-parameters
+#  valid_step: 5000
+  valid_step: 100
+  max_step: 1000
+  tf_start: 1.0
+  tf_end: 1.0
+  tf_step: 500000
+  optimizer: 'Adadelta'
+  lr: 1.0
+  eps: 0.00000001                         # 1e-8
+  lr_scheduler: 'fixed'                   # 'fixed'/'warmup'
+  curriculum: 0
+
+model:                                    # Model architecture
+  ctc_weight: 1.0                         # Weight for CTC loss
+  encoder:
+    prenet: 'vgg'                         # 'vgg'/'cnn'/'mlp'
+    # vgg: True                             # 4x reduction on time feature extraction
+    module: 'cnn'                        # 'LSTM'/'GRU'/'Transformer'/'mlp'/'cnn'
+#    module: 'Transformer'                        # 'LSTM'/'GRU'/'Transformer'
+    bidirection: True
+    dim: [512,512,512,512,512]
+    dropout: [0,0,0,0,0]
+    layer_norm: [False,False,False,False,False]
+    proj: [True,True,True,True,True]      # Linear projection + Tanh after each rnn layer
+    sample_rate: [1,1,1,1,1]
+    sample_style: 'drop'                  # 'drop'/'concat'
+  attention:
+    mode: 'loc'                           # 'dot'/'loc'
+    dim: 300
+    num_head: 1
+    v_proj: False                         # if False and num_head>1, encoder state will be duplicated for each head
+    temperature: 0.5                      # scaling factor for attention
+    loc_kernel_size: 100                  # just for mode=='loc'
+    loc_kernel_num: 10                    # just for mode=='loc'
+  decoder:
+    module: 'LSTM'                        # 'LSTM'/'GRU'/'Transformer'
+    dim: 512
+    layer: 1
+    dropout: 0

--- a/corpus/tedsrt.py
+++ b/corpus/tedsrt.py
@@ -1,6 +1,7 @@
 from tqdm import tqdm
 from pathlib import Path
 from os.path import join, getsize
+from ntpath import basename
 from joblib import Parallel, delayed
 from torch.utils.data import Dataset
 
@@ -19,7 +20,7 @@ def read_text(file):
        it's somewhat redundant for accessing each txt multiplt times,
        but it works fine with multi-thread'''
     src_file = '-'.join(file.split('-')[:-1])+'.trans.txt'
-    idx = file.split('/')[-1].split('.')[0]
+    idx = basename(file).split('.')[0]
 
     with open(src_file, 'r') as fp:
         for line in fp:

--- a/src/asr.py
+++ b/src/asr.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.distributions.categorical import Categorical
 
-from src.classifier import MLPCLassfier
+from src.classifier import MLPCLassfier, CNNClassifier
 from src.util import init_weights, init_gate
 from src.module import CNNExtractor, RNNLayer, ScaleDotAttention, LocationAwareAttention
 from src.extractor import VGGExtractor, MLPExtractor, RNNExtractor, ANNExtractor
@@ -393,6 +393,9 @@ class Encoder(nn.Module):
                 self.out_dim = input_dim
         elif module == 'mlp':
             self.classifier = MLPCLassfier(input_dim)
+            self.out_dim = self.classifier.out_dim
+        elif module == 'cnn':
+            self.classifier = CNNClassifier(input_dim)
             self.out_dim = self.classifier.out_dim
         else:
             raise NotImplementedError

--- a/src/classifier.py
+++ b/src/classifier.py
@@ -1,4 +1,6 @@
+import torch
 from torch import nn as nn
+from torch.nn import functional as F
 
 
 class MLPCLassfier(nn.Module):
@@ -35,24 +37,24 @@ class MLPCLassfier(nn.Module):
 class CNNClassifier(nn.Module):
     def __init__(self, input_dim):
         super(CNNClassifier, self).__init__()
-        hidden_dim_1 = 64
-        hidden_dim_2 = hidden_dim_1 * 2
+        self.hidden_dim_1 = hidden_dim_1 = input_dim // 16
+        self.hidden_dim_2 = hidden_dim_2 = hidden_dim_1 * 2
 
-        self.out_dim = input_dim * 8
-        self.classifier = nn.Sequential(
-            nn.Conv2d(in_channels=1, out_channels=hidden_dim_1, kernel_size=(3,), stride=(1,), padding=(1,)),
-            nn.ReLU(),
-            nn.Conv2d(in_channels=hidden_dim_1, out_channels=hidden_dim_1, kernel_size=(3,), stride=(1,), padding=(1,)),
-            nn.ReLU(),
-            nn.MaxPool2d(2, stride=2),
-            nn.Conv2d(in_channels=hidden_dim_1, out_channels=hidden_dim_2, kernel_size=(3,), stride=(1,), padding=(1,)),
-            nn.ReLU(),
-            nn.Conv2d(in_channels=hidden_dim_2, out_channels=hidden_dim_2, kernel_size=(3,), stride=(1,), padding=(1,)),
-            nn.ReLU(),
-            nn.MaxPool2d(2, stride=2),
-            nn.Linear((input_dim // 4) * hidden_dim_2, self.out_dim),
-        )
+        self.out_dim = input_dim // 4
 
+        conv_hyperparams = {
+            "kernel_size": (3,3),
+            "dilation": (1,1),
+            "stride": (1,1),
+            "padding": (1,1),
+        }
+
+        self.conv1 = nn.Conv2d(in_channels=1, out_channels=hidden_dim_1, **conv_hyperparams)
+        self.conv2 = nn.Conv2d(in_channels=hidden_dim_1, out_channels=hidden_dim_1, **conv_hyperparams)
+        self.conv3 = nn.Conv2d(in_channels=hidden_dim_1, out_channels=hidden_dim_2, **conv_hyperparams)
+        self.conv4 = nn.Conv2d(in_channels=hidden_dim_2, out_channels=hidden_dim_2, **conv_hyperparams)
+        self.dense = nn.Linear(hidden_dim_2 * self.out_dim, self.out_dim)
+        self.pool = nn.MaxPool2d((1,2))
 
     def reshape_input(self, feature, group_size):
         down_sample_len = feature.size(1) // group_size
@@ -60,9 +62,29 @@ class CNNClassifier(nn.Module):
         reshape_feature = feature.reshape(feature.size(0) * down_sample_len, group_size*feature.size(2))
         return reshape_feature
 
-
     def forward(self, feature):
-        print(f"{feature}\n\nSize:{feature.size()}")
-        return self.classifier(feature)
+        # Input size is varied - size is N timesteps x 384 features. Batch size = 1 and number of input channels = 1.
+        # Therefore, inputs must be unsqueezed.
+        feature = feature.unsqueeze(dim=0).unsqueeze(dim=1)
+
+        # Format: input_channels x timesteps x features --> output_channels x new_timesteps x new_features
+        feature = self.conv1(feature)  # 1 x N x 384 --> 24 x N x 384
+        feature = F.relu(feature)
+        feature = self.conv2(feature)  # 24 x N x 384 --> 24 x N x 384
+        feature = F.relu(feature)
+        feature = self.pool(feature)  # 24 x N x 384 --> 24 x N x 192
+        feature = self.conv3(feature)  # 24 x N x 192 --> 48 x N x 192
+        feature = F.relu(feature)
+        feature = self.conv4(feature)  # 48 x N x 192 --> 48 x N x 192
+        feature = F.relu(feature)
+        feature = self.pool(feature)  # 48 x N x 192 --> 48 x N x 96
+
+        feature = feature.transpose(0, 1)  # 48 x N x 96 --> N x 48 x 96
+        feature = feature.view(-1, self.hidden_dim_2 * self.out_dim) # N x 48 x 96 --> N x (48 x 96)
+        feature = torch.stack([
+            self.dense(feature[index].unsqueeze(dim=0)) 
+            for index in range(feature.size()[0])])  # N x (48 x 96) --> N x 96
+        feature = feature.transpose(0, 1)  # N x 96 --> 96 x N
+        return feature
 
 

--- a/src/classifier.py
+++ b/src/classifier.py
@@ -30,3 +30,39 @@ class MLPCLassfier(nn.Module):
 
 
         return self.classifier(feature)
+
+
+class CNNClassifier(nn.Module):
+    def __init__(self, input_dim):
+        super(CNNClassifier, self).__init__()
+        hidden_dim_1 = 64
+        hidden_dim_2 = hidden_dim_1 * 2
+
+        self.out_dim = input_dim * 8
+        self.classifier = nn.Sequential(
+            nn.Conv2d(in_channels=1, out_channels=hidden_dim_1, kernel_size=(3,), stride=(1,), padding=(1,)),
+            nn.ReLU(),
+            nn.Conv2d(in_channels=hidden_dim_1, out_channels=hidden_dim_1, kernel_size=(3,), stride=(1,), padding=(1,)),
+            nn.ReLU(),
+            nn.MaxPool2d(2, stride=2),
+            nn.Conv2d(in_channels=hidden_dim_1, out_channels=hidden_dim_2, kernel_size=(3,), stride=(1,), padding=(1,)),
+            nn.ReLU(),
+            nn.Conv2d(in_channels=hidden_dim_2, out_channels=hidden_dim_2, kernel_size=(3,), stride=(1,), padding=(1,)),
+            nn.ReLU(),
+            nn.MaxPool2d(2, stride=2),
+            nn.Linear((input_dim // 4) * hidden_dim_2, self.out_dim),
+        )
+
+
+    def reshape_input(self, feature, group_size):
+        down_sample_len = feature.size(1) // group_size
+        feature = feature[:,:down_sample_len*group_size,:]
+        reshape_feature = feature.reshape(feature.size(0) * down_sample_len, group_size*feature.size(2))
+        return reshape_feature
+
+
+    def forward(self, feature):
+        print(f"{feature}\n\nSize:{feature.size()}")
+        return self.classifier(feature)
+
+


### PR DESCRIPTION
Implemented CNNClassifier.

Note that due to the variable number of timesteps for each input, the dense layer is applied on each timestep individually.
The convolutional layers apply as-per normal across timesteps, and the MaxPool layers ignore timesteps (i.e. they only pool features).

Command to run: `python3 main.py --config config/ted/asr_sam_cnnclassifier.yaml --njobs 8`